### PR TITLE
Topull

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,20 +13,20 @@ A parser plugin for fis to compile dust file.
 fis.config.merge({
     roadmap : {
         ext : {
-            dust : 'dustjs'
+            dust : 'js'
         },
-        path : {
+        path : [{  // maybe you need fis.config.concat instead of fis.config.merge
             reg: /\/dust\/(.*)\.dust$/,    // your location of dust files
             isMod: true,
             useParser: true,
             useCompile: true,
             isJsLike: true,
             release: '/static/dust/$1.js'  // your release path of dust files
-        }
+        }]
     },
     modules : {
         parser : {
-            dust : 'dust'
+            dust : 'dustjs'
         }
     },
     settings : {

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A parser plugin for fis to compile dust file.
 
 ## usage
 
-    $ npm install -g fis-parser-dust
+    $ npm install -g fis-parser-dustjs
     $ vi path/to/project/fis-conf.js
 
 ```javascript
@@ -13,7 +13,15 @@ A parser plugin for fis to compile dust file.
 fis.config.merge({
     roadmap : {
         ext : {
-            dust : 'dust'
+            dust : 'dustjs'
+        },
+        path : {
+            reg: /\/dust\/(.*)\.dust$/,    // your location of dust files
+            isMod: true,
+            useParser: true,
+            useCompile: true,
+            isJsLike: true,
+            release: '/static/dust/$1.js'  // your release path of dust files
         }
     },
     modules : {

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A parser plugin for fis to compile dust file.
 
 ## usage
 
-    $ npm install -g fis-parser-dustjs
+    $ npm install -g fis-parser-dust
     $ vi path/to/project/fis-conf.js
 
 ```javascript
@@ -26,7 +26,7 @@ fis.config.merge({
     },
     modules : {
         parser : {
-            dust : 'dustjs'
+            dust : 'dust'
         }
     },
     settings : {

--- a/index.js
+++ b/index.js
@@ -10,5 +10,5 @@ var dust = require('dustjs-linkedin');
 
 module.exports = function(content, file, conf){
 	var name = conf.basePath ? conf.basePath + file.filename : file.subpathNoExt;
-    return "define('" + file.id + "', function () {\n\t" + dust.compile(content.toString(), name) + "\n});";
+    return "define('" + file.getId() + "', function (require, exports, module) {\n\t" + dust.compile(content.toString(), name) + "\n});";
 };

--- a/index.js
+++ b/index.js
@@ -10,5 +10,5 @@ var dust = require('dustjs-linkedin');
 
 module.exports = function(content, file, conf){
 	var name = conf.basePath ? conf.basePath + file.filename : file.subpathNoExt;
-    return "define(function () {\n\t" + dust.compile(content.toString(), name) + "\n});";
+    return "define('" + file.id + "', function () {\n\t" + dust.compile(content.toString(), name) + "\n});";
 };

--- a/package.json
+++ b/package.json
@@ -1,14 +1,14 @@
 {
-    "name" : "fis-parser-dustjs",
+    "name" : "fis-parser-dust",
     "description" : "A parser plugin for fis to compile dust file.",
     "version" : "0.0.2",
     "author" : "FIS Team <fis@baidu.com>; yqt0221@gmail.com; v@luzhe.info",
-    "homepage" : "https://github.com/5percent/fis-parser-dust",
+    "homepage" : "https://github.com/yqt/fis-parser-dust",
     "keywords": [ "fis", "dust", "dustjs-linkedin" ],
     "main" : "index.js",
     "repository": {
         "type": "git",
-        "url": "https://github.com/5percent/fis-parser-dust.git"
+        "url": "https://github.com/yqt/fis-parser-dust.git"
     },
     "engines" : {
         "node" : ">= 0.8.0"

--- a/package.json
+++ b/package.json
@@ -1,14 +1,14 @@
 {
-    "name" : "fis-parser-dust",
+    "name" : "fis-parser-dustjs",
     "description" : "A parser plugin for fis to compile dust file.",
-    "version" : "0.0.1",
-    "author" : "FIS Team <fis@baidu.com>; yqt0221@gmail.com",
-    "homepage" : "https://github.com/yqt/fis-parser-dust",
+    "version" : "0.0.2",
+    "author" : "FIS Team <fis@baidu.com>; yqt0221@gmail.com; v@luzhe.info",
+    "homepage" : "https://github.com/5percent/fis-parser-dust",
     "keywords": [ "fis", "dust", "dustjs-linkedin" ],
     "main" : "index.js",
     "repository": {
         "type": "git",
-        "url": "https://github.com/yqt/fis-parser-dust.git"
+        "url": "https://github.com/5percent/fis-parser-dust.git"
     },
     "engines" : {
         "node" : ">= 0.8.0"


### PR DESCRIPTION
There is a bug if without 'file.id' in define. Cause the map files couldn't find the correct path of the released dust files.
